### PR TITLE
Clean up imports and update stock PATCH tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Authorization: Bearer your-auth-token
 
 #### Add Stock
 ```http
-POST /stock/{id}/stock
+PATCH /stock/{id}/stock/add
 Authorization: Bearer your-auth-token
 Content-Type: application/json
 
@@ -135,7 +135,7 @@ Content-Type: application/json
 
 #### Remove Stock
 ```http
-DELETE /stock/{id}/stock
+PATCH /stock/{id}/stock/remove
 Authorization: Bearer your-auth-token
 Content-Type: application/json
 

--- a/shoptrack/__init__.py
+++ b/shoptrack/__init__.py
@@ -1,5 +1,4 @@
 import os
-import logging
 
 from flask import Flask, jsonify
 from flask_cors import CORS

--- a/shoptrack/validation.py
+++ b/shoptrack/validation.py
@@ -1,4 +1,4 @@
-from flask import jsonify, g, request
+from flask import g, request
 from shoptrack.db import get_db, get_placeholder, execute_query
 
 def validate_product_data(data, required_fields=None):

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -56,23 +56,23 @@ def test_create_product_invalid_data(client):
 def test_add_stock(client):
     token = get_test_user_token(client)
     headers = {'Authorization': f'Bearer {token}'}
-    
+
     # Use existing test product (ID 1 from data.sql)
     stock_data = {'stock': 5}
-    response = client.post('/stock/1/stock', 
-                          json=stock_data, 
-                          headers=headers)
+    response = client.patch('/stock/1/stock/add',
+                           json=stock_data,
+                           headers=headers)
     assert response.status_code == 200
     assert b'Stock added successfully' in response.data
 
 def test_remove_stock(client):
     token = get_test_user_token(client)
     headers = {'Authorization': f'Bearer {token}'}
-    
+
     # Use existing test product (ID 1 from data.sql)
     stock_data = {'stock': 3}
-    response = client.delete('/stock/1/stock', 
-                            json=stock_data, 
+    response = client.patch('/stock/1/stock/remove',
+                            json=stock_data,
                             headers=headers)
     assert response.status_code == 200
     assert b'Stock removed successfully' in response.data


### PR DESCRIPTION
## Summary
- remove unused logging and jsonify imports
- document new PATCH endpoints for adding and removing stock
- update stock tests for new PATCH add/remove endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b11f112a808328b74eb7264a95ec51